### PR TITLE
Update sphere_fibonacci_grid_points.m

### DIFF
--- a/sphere_fibonacci_grid/sphere_fibonacci_grid_points.m
+++ b/sphere_fibonacci_grid/sphere_fibonacci_grid_points.m
@@ -25,16 +25,21 @@ function xg = sphere_fibonacci_grid_points ( ng )
 %
 %  Parameters:
 %
-%    Input, integer NG, the number of points.
+%    Input, odd integer NG, the number of points.
 %
 %    Output, real XG(N,3), the grid points.
 %
-  phi = ( 1.0 + sqrt ( 5.0 ) ) / 2.0;
 
-  i = ( - ( ng - 1 ) : 2 : ( ng - 1 ) )';
+  validateattributes(ng, {'numeric'}, {'odd', 'nonnegative'});
+
+  phi = ( 1.0 + sqrt ( 5.0 ) ) / 2.0;
+  
+  N = round(ng/2)-1; % resolution, analogous to N in the paper
+  i = ( -N : 1 : N )';
+  
   theta = 2 * pi * i / phi;
-  sphi = i / ng;
-  cphi = sqrt ( ( ng + i ) .* ( ng - i ) ) / ng;
+  sphi = 2 * i / ( 2 * N + 1 );
+  cphi = sqrt ( ( N + i ) .* ( N - i ) ) / N;
 
   xg = zeros ( ng, 3 );
 


### PR DESCRIPTION
The original code produced points that were actually not uniformly distributed on a sphere. The points were on clearly distinguishable spirals with larger gaps between them. You can see the difference in the attached figures; the number of points is 5001. I have not numerically checked whether my code is correct, but it directly implements the equations in the paper and the resulting points look exactly like the example figures in the paper.
Also, I failed to find an e-mail address of John Burkardt, hence I did not contact him in this issue.

![new](https://user-images.githubusercontent.com/11832636/51475170-e61a9800-1d81-11e9-9d15-56cfe0d6fbfb.png) ![old](https://user-images.githubusercontent.com/11832636/51475171-e6b32e80-1d81-11e9-8337-2bad8eae7dd8.png)